### PR TITLE
catch all notice changes

### DIFF
--- a/articles/xml/201/501/321.xml
+++ b/articles/xml/201/501/321.xml
@@ -433,10 +433,8 @@
             <P>(4) * * *</P>
             <P>(ii) Under the subheading &#x201C;Final,&#x201D; the total amount of payoffs and payments made to third parties disclosed pursuant to paragraph (t)(5)(vii)(B) of this section, to the extent known, disclosed as a negative number;</P>
             <STARS/>
-            <P>
-              <E T="03">(j)</E>* * *</P>
-            <P>
-              <E T="03">(2)</E>* * *</P>
+            <P>(j)* * *</P>
+            <P>(2)* * *</P>
             <P>(iv) The amount of any existing loans that the consumer is assuming, or any loans subject to which the consumer is taking title to the property, labeled &#x201C;Existing Loan(s) Assumed or Taken Subject to&#x201D;;</P>
             <STARS/>
             <P>(k) * * *</P>
@@ -444,10 +442,8 @@
             <P>(v) The amount of any loan secured by a first lien on the property that will be paid off as part of the real estate closing, labeled &#x201C;Payoff of First Mortgage Loan&#x201D;;</P>
             <P>(vi) The amount of any loan secured by a second lien on the property that will be paid off as part of the real estate closing, labeled &#x201C;Payoff of Second Mortgage Loan&#x201D;;</P>
             <STARS/>
-            <P>
-              <E T="03">(t)</E>* * *</P>
-            <P>
-              <E T="03">(4)</E>* * *</P>
+            <P>(t)* * *</P>
+            <P>(4)* * *</P>
             <P>(ii)<E T="03">Percentages.</E>The percentage amounts required to be disclosed under paragraphs (b), (f)(1), (n), and (o)(5) of this section shall not be rounded and shall be disclosed up to two or three decimal places. The percentage amount required to be disclosed under paragraph (o)(4) of this section shall not be rounded and shall be disclosed up to three decimal places. If the amount is a whole number then the amount disclosed shall be truncated at the decimal point.</P>
             <STARS/>
           </SECTION>
@@ -480,7 +476,7 @@
 
           <AMDPAR>iv. Under paragraph 37(h)(1)(ii), paragraph 1 is revised.<PRTPAGE P="8777"/>
           </AMDPAR>
-          <AMDPAR>v. Under paragraph 37(m), 37(m)(8) is added and paragraph 1 is added.</AMDPAR>
+          <AMDPAR>v. Under paragraph 37(m), paragraph 37(m)(8) is added.</AMDPAR>
           <AMDPAR>vi. Under paragraph 37(n), paragraph 2 is revised.</AMDPAR>
           <AMDPAR>c. Under<E T="03">Section 1026.38&#x2014;Content of Disclosures for Certain Mortgage Transactions (Closing Disclosure):</E>
           </AMDPAR>


### PR DESCRIPTION
This notice was skipping over these changes due to the extra `<E>` tags.
