### PR TITLE
Remove paragraph markers

### DIFF
--- a/annual/CFR-2012-title12-vol8-part1004.xml
+++ b/annual/CFR-2012-title12-vol8-part1004.xml
@@ -52,22 +52,22 @@
       <SECTNO>§ 1004.2</SECTNO>
       <SUBJECT>Definitions.</SUBJECT>
       <P>For purposes of this part:</P>
-      <P>(a)
+      <P>
         <E T="03">Alternative mortgage transaction</E> means a loan, credit sale, or account:</P>
       <P>(1) That is secured by an interest in a residential structure that contains one to four units, whether or not that structure is attached to real property, including an individual condominium unit, cooperative unit, mobile home, or trailer, if it is used as a residence;</P>
       <P>(2) That is made primarily for personal, family, or household purposes; and</P>
       <P>(3) In which the interest rate or finance charge may be adjusted or renegotiated.</P>
-      <P>(b)
+      <P>
         <E T="03">Creditor</E> shall have the same meaning as in 12 CFR 226.2.</P>
-      <P>(c)
+      <P>
         <E T="03">Housing creditor</E> means:</P>
       <P>(1) A depository institution, as defined in section 501(a)(2) of the Depository Institutions Deregulation and Monetary Control Act of 1980;</P>
       <P>(2) A lender approved by the Secretary of Housing and Urban Development for participation in any mortgage insurance program under the National Housing Act;</P>
       <P>(3) Any person who regularly makes loans, credit sales, or advances on an account secured by an interest in a residential structure that contains one to four units, whether or not the structure is attached to real property, including an individual condominium unit, cooperative unit, mobile home, or trailer, if it is used as a residence; and</P>
       <P>(4) Any transferee of a party listed in paragraph (c)(1), (2), or (3) of this section.</P>
-      <P>(d)
+      <P>
         <E T="03">State</E> means any State of the United States of America, the District of Columbia, Puerto Rico, the Virgin Islands, the Northern Mariana Islands, American Samoa, Guam, and any other territory or possession of the United States.</P>
-      <P>(e)
+      <P>
         <E T="03">State law</E> means a State constitution, statute, or regulation or any provision thereof.</P>
     </SECTION>
     <SECTION>


### PR DESCRIPTION
The first annual edition of 1004 appears to have been modified to add
paragraph markers for 1004.2's definitions. This does not match the original
XML, the modified notice (2011-18676), or the live site, so I'm assuming that
was an accident.
